### PR TITLE
added migration and model for vote

### DIFF
--- a/app/Models/Poll.php
+++ b/app/Models/Poll.php
@@ -15,4 +15,9 @@ class Poll extends Model
         'end_date',
         'phase',
     ];
+
+    public function votes()
+    {
+        return $this->hasMany(Vote::class);
+    }
 }

--- a/app/Models/Poll.php
+++ b/app/Models/Poll.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Poll extends Model
 {
@@ -16,7 +17,7 @@ class Poll extends Model
         'phase',
     ];
 
-    public function votes()
+    public function votes(): HasMany
     {
         return $this->hasMany(Vote::class);
     }

--- a/app/Models/Vote.php
+++ b/app/Models/Vote.php
@@ -4,6 +4,8 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Mockery\Undefined;
 
 class Vote extends Model
 {
@@ -14,7 +16,7 @@ class Vote extends Model
         'description',
     ];
 
-    public function poll()
+    public function poll(): BelongsTo
     {
         return $this->belongsTo(Poll::class);
     }

--- a/app/Models/Vote.php
+++ b/app/Models/Vote.php
@@ -13,4 +13,9 @@ class Vote extends Model
         'id',
         'description',
     ];
+
+    public function poll()
+    {
+        return $this->belongsTo(Poll::class);
+    }
 }

--- a/app/Models/Vote.php
+++ b/app/Models/Vote.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Vote extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'id',
+        'description',
+    ];
+}

--- a/database/migrations/2023_01_26_103237_create_votes_table.php
+++ b/database/migrations/2023_01_26_103237_create_votes_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('votes', function (Blueprint $table) {
+            $table->id();
+            $table->integer('description');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('votes');
+    }
+};

--- a/database/migrations/2023_01_26_103237_create_votes_table.php
+++ b/database/migrations/2023_01_26_103237_create_votes_table.php
@@ -16,6 +16,7 @@ return new class extends Migration
         Schema::create('votes', function (Blueprint $table) {
             $table->id();
             $table->integer('description');
+            $table->foreignId('poll_id')->constrained('polls');
             $table->timestamps();
         });
     }
@@ -27,6 +28,9 @@ return new class extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('votes');
+        Schema::table('votes', function (Blueprint $table){
+            $table->dropForeign('votes_poll_id_foreign');
+        }); 
+        Schema::dropIfExists('votes'); 
     }
 };

--- a/database/migrations/2023_01_26_103237_create_votes_table.php
+++ b/database/migrations/2023_01_26_103237_create_votes_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
         Schema::create('votes', function (Blueprint $table) {
             $table->id();
             $table->integer('description');
-            $table->foreignId('poll_id')->constrained('polls');
+            $table->foreignId('poll_id')->constrained('polls')->onDelete('cascade');
             $table->timestamps();
         });
     }


### PR DESCRIPTION
Fixes #2 

This PR introduces a model and migration for votes as well as a one-to-many relationship between the two entities Poll and Vote. 

Since the [documentation](https://laravel.com/docs/9.x/eloquent-relationships) specifies that the foreign key for the child model will be automatically determined by Eloquent, I don't think we have to add a db-migration to ensure the relationship between the two (e.g. by adding the foreign key of the polls table to the votes table). 

Looking forward to your feedback, especially regarding the one-to-many relationship :blush: 