### PR TITLE
Create fake data for polls and votes

### DIFF
--- a/app/Console/Commands/Seed.php
+++ b/app/Console/Commands/Seed.php
@@ -33,7 +33,7 @@ class Seed extends Command
         $randCountOfVotes = rand(10, 150);
 
         Poll::factory()
-            ->count($this->argument("amountOfPolls"))
+            ->count((int)$this->argument("amountOfPolls"))
             ->has(Vote::factory()->count($randCountOfVotes))
             ->create();
 

--- a/app/Console/Commands/Seed.php
+++ b/app/Console/Commands/Seed.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Models\Poll;
+use App\Models\Vote;
 use Database\Factories\PollFactory;
 use Illuminate\Console\Command;
 
@@ -13,7 +14,7 @@ class Seed extends Command
      *
      * @var string
      */
-    protected $signature = 'seed';
+    protected $signature = 'seed {amountOfPolls=10}';
 
     /**
      * The console command description.
@@ -29,7 +30,13 @@ class Seed extends Command
      */
     public function handle(): int
     {
-        Poll::factory()->count(5)->create();
+        $randCountOfVotes = rand(10, 150);
+
+        Poll::factory()
+            ->count($this->argument("amountOfPolls"))
+            ->has(Vote::factory()->count($randCountOfVotes))
+            ->create();
+
         return Command::SUCCESS;
     }
 }

--- a/app/Console/Commands/Seed.php
+++ b/app/Console/Commands/Seed.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Poll;
+use Database\Factories\PollFactory;
+use Illuminate\Console\Command;
+
+class Seed extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'seed';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Use factory to seed db.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        Poll::factory()->count(5)->create();
+        return Command::SUCCESS;
+    }
+}

--- a/app/Console/Commands/Seed.php
+++ b/app/Console/Commands/Seed.php
@@ -27,7 +27,7 @@ class Seed extends Command
      *
      * @return int
      */
-    public function handle()
+    public function handle(): int
     {
         Poll::factory()->count(5)->create();
         return Command::SUCCESS;

--- a/database/factories/PollFactory.php
+++ b/database/factories/PollFactory.php
@@ -19,10 +19,13 @@ class PollFactory extends Factory
      */
     public function definition()
     {
+        $randMinLength = rand(5, 15);
+        $randMaxLength = rand(20, 60);
+
         return [
-            'name' => fake()->realText(),
+            'name' => fake()->realTextBetween($randMinLength, $randMaxLength),
             'description' => fake()->realText(),
-            'end_date' => fake()->date(),
+            'end_date' => fake()->dateTimeBetween('-1 week', '+8 weeks'),
             'phase' => 1,
         ];
     }

--- a/database/factories/PollFactory.php
+++ b/database/factories/PollFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Poll;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Poll>
+ */
+class PollFactory extends Factory
+{
+    protected $model = Poll::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'name' => fake()->realText(),
+            'description' => fake()->realText(),
+            'end_date' => fake()->date(),
+            'phase' => 1,
+        ];
+    }
+}

--- a/database/factories/VoteFactory.php
+++ b/database/factories/VoteFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Vote>
+ */
+class VoteFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'description' => fake()->boolean(60),
+        ];
+    }
+}


### PR DESCRIPTION
This PR solves #37 and adds a vote and a poll factory. These factories describe the kind of data needed to create a poll and a vote. The data itself is created with FakePHP. 

With the seed command `ddev exec php artisan seed 20`, 20 polls and a random amount of votes for each poll are created.